### PR TITLE
Changes callbacks to method calls in controller actions.

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -11,6 +11,7 @@ class ReservationsController < ApplicationController
 
     if @reservation.save
       flash[:notice] = "Sending your reservation request now."
+      @reservation.notify_host
       redirect_to @vacation_property
     else
       flast[:danger] = @reservation.errors

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -8,9 +8,6 @@ class Reservation < ActiveRecord::Base
   belongs_to :vacation_property
   belongs_to :user
 
-  after_create :notify_host
-  after_update :notify_guest
-
   def notify_host(force = false)
     @host = User.find(self.vacation_property[:user_id])
 
@@ -18,7 +15,7 @@ class Reservation < ActiveRecord::Base
     if @host.pending_reservations.length > 1 or !force
       return
     else
-      message = "You have a new reservation request from #{self.name} for #{self.vacation_property.description}: 
+      message = "You have a new reservation request from #{self.name} for #{self.vacation_property.description}:
 
       '#{self.message}'
 
@@ -38,14 +35,12 @@ class Reservation < ActiveRecord::Base
     self.save
   end
 
-  private
+  def notify_guest
+    @guest = User.find_by(phone_number: self.phone_number)
 
-    def notify_guest
-      @guest = User.find_by(phone_number: self.phone_number)
-
-      if self.status_changed? && (self.status == "confirmed" || self.status == "rejected")
-        message = "Your recent request to stay at #{self.vacation_property.description} was #{self.status}."
-        @guest.send_message_via_sms(message)
-      end
+    if self.status_changed? && (self.status == "confirmed" || self.status == "rejected")
+      message = "Your recent request to stay at #{self.vacation_property.description} was #{self.status}."
+      @guest.send_message_via_sms(message)
     end
+  end
 end


### PR DESCRIPTION
This is a personal preference, but one that I believe many other developers are
following too. Callbacks on models can hide the complexity that is happening in
a controller action. Making the calls explicitly within the action shows exactly
what that action is up to. Other things this helps with are tests or admin
actions, where you don't get unintended side effects if you create an object
outside of its normal life. There are some blog posts on this, for example
[here](http://adequate.io/culling-the-activerecord-lifecycle) and [here](https://www.reinteractive.net/posts/130-activerecord-callbacks-considered-harmful).
